### PR TITLE
Adjust javscripts: Use $ instead of deprecated jq.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
+- Adjust javscripts: Use $ instead of deprecated jq.
+  [phgross]
+
 - Added functionality wich allows using html tags as tooltip data.
   [phgross]
 

--- a/ftw/tooltip/browser/tooltip_template.js.pt
+++ b/ftw/tooltip/browser/tooltip_template.js.pt
@@ -3,10 +3,10 @@
 var ftwtooltips = <span tal:replace="ftwtooltips" />;
 
 function ShowTooltip(item){
-    jq(item.selector).live('mouseover', function(e){
+    $(item.selector).live('mouseover', function(e){
 
         e.preventDefault();
-        var $this = jq(this);
+        var $this = $(this);
         if (item.text){
 
             $this.attr('title', item.text);
@@ -22,7 +22,7 @@ function ShowTooltip(item){
             }
 
             var customconfig = <span tal:replace="structure view/get_custom_config" />;
-            var settings = jq.extend({
+            var settings = $.extend({
                 tipClass:'',
                 delay:0,
                 cancelDefault: true,
@@ -41,9 +41,9 @@ function ShowTooltip(item){
     });
 }
 
-jq(function(){
-    jq(ftwtooltips).each(function(i, o){
-        if (jq(o.condition).length !== 0){
+$(function(){
+    $(ftwtooltips).each(function(i, o){
+        if ($(o.condition).length !== 0){
             ShowTooltip(o);
         }
 


### PR DESCRIPTION
The jq function is deprecated, and plone.app.jquery removes the jquery-integration.js in the newest Version, so i replaced all the jq function with $ function.

Now the javascript part works also without the jquery-integration.js.

@maethu: please have a look!
